### PR TITLE
Update compatibility with 2022.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,15 +6,15 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.6.0"
+    id("org.jetbrains.kotlin.jvm") version "1.7.10"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "1.5.3"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.3.1"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.20.0"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "10.2.1"
+    id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
     // dependency checker
     id("com.github.ben-manes.versions") version "0.36.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@
 
 pluginGroup = dev.lankydan.palenightintellijtheme
 pluginName_ = palenight-intellij-theme
-pluginVersion = 0.0.7
+pluginVersion = 0.0.8
 pluginSinceBuild = 193
-pluginUntilBuild = 221.*
+pluginUntilBuild = 222.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3, 2021.1.1, 2022.1
+pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3, 2021.1.1, 2022.1, 2022.2, 2022.2.1
 
 platformType = IC
-platformVersion = 2022.1
+platformVersion = 2022.2
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
I looked on the previous commit on upgrading to 2022.1 and test using local build seem to work fine

Change proposed in this pull request:
* Bump plugin version to 0.8.0
* Increase intellij compatibility build to 222.*
* Include 2022.2 and 2022.2.1 in pluginVerifierIdeVersions 
* Upgrade kotlin dependencies to 1.7.10
* Upgrade detekt to 1.21.0
* Upgrade ktlint to 10.3.0