### PR TITLE
Update pluginUntilBuild to support Android Studio 252+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = dev.lankydan.palenightintellijtheme
 pluginName_ = palenight-intellij-theme
 pluginVersion = 1.0.6
 pluginSinceBuild = 241
-pluginUntilBuild = 251.*
+pluginUntilBuild = 252.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2024.2, 2024.3, 2025.1


### PR DESCRIPTION
Updated `pluginUntilBuild` in `gradle.properties` to allow the plugin to work with Android Studio Otter (build 252). Tested locally, and the theme now loads without errors. 

This allows users on the latest IDE to use the Palenight theme without issues.
<img width="786" height="636" alt="2" src="https://github.com/user-attachments/assets/ca885c71-abca-473d-a0b3-595d04b29679" />